### PR TITLE
Fixed width writer: Change truncation behavior so it respects field alignment

### DIFF
--- a/FlatFiles.Test/FixedLengthWriterTester.cs
+++ b/FlatFiles.Test/FixedLengthWriterTester.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FlatFiles.TypeMapping;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FlatFiles.Test
+{
+    [TestClass]
+    public class FixedLengthWriterTester
+    {
+        /// <summary>
+        /// When outputting a value whose length is wider than the column, it should truncate the
+        /// value (keeping only the end)
+        /// </summary>
+        [TestMethod]
+        public void TestWrite_ValueTooWide_Truncates()
+        {
+            var schema = new FixedLengthSchema();
+            schema.AddColumn(new StringColumn("Name"), 5);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (var writer = new FixedLengthWriter(stream, schema))
+                {
+                    writer.Write(new object[] { "1234567890" });
+                    writer.Flush();
+
+                    stream.Position = 0;  // go back to the beginning of the stream
+
+                    FlatFileReader reader = new FlatFileReader(new FixedLengthReader(stream, schema));
+                    Assert.IsTrue(reader.Read(), "The writer did not write the entities.");
+                    
+                    string value = reader.GetString(0);
+                    
+                    Assert.AreEqual("67890", value, "The value was not truncated properly.");
+                    Assert.IsFalse(reader.Read(), "The writer wrote too many records.");
+                }
+            }
+        }
+    }
+}

--- a/FlatFiles.Test/FixedLengthWriterTester.cs
+++ b/FlatFiles.Test/FixedLengthWriterTester.cs
@@ -13,13 +13,14 @@ namespace FlatFiles.Test
     {
         /// <summary>
         /// When outputting a value whose length is wider than the column, it should truncate the
-        /// value (keeping only the end)
+        /// value. If the column's Alignment is Left, then it should keep the start of the value
+        /// and chop off the end.
         /// </summary>
         [TestMethod]
-        public void TestWrite_ValueTooWide_Truncates()
+        public void TestWrite_LeftAlignedValueTooWide_TruncatesKeepingLeft()
         {
             var schema = new FixedLengthSchema();
-            schema.AddColumn(new StringColumn("Name"), 5);
+            schema.AddColumn(new StringColumn("Name"), new Window(5, FixedAlignment.LeftAligned));
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -35,6 +36,37 @@ namespace FlatFiles.Test
                     
                     string value = reader.GetString(0);
                     
+                    Assert.AreEqual("12345", value, "The value was not truncated properly.");
+                    Assert.IsFalse(reader.Read(), "The writer wrote too many records.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// When outputting a value whose length is wider than the column, it should truncate the
+        /// value. If the column's Alignment is Right, then it should keep the end of the value
+        /// and chop off the start.
+        /// </summary>
+        [TestMethod]
+        public void TestWrite_RightAlignedValueTooWide_TruncatesKeepingRight()
+        {
+            var schema = new FixedLengthSchema();
+            schema.AddColumn(new StringColumn("Name"), new Window(5, FixedAlignment.RightAligned));
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (var writer = new FixedLengthWriter(stream, schema))
+                {
+                    writer.Write(new object[] { "1234567890" });
+                    writer.Flush();
+
+                    stream.Position = 0;  // go back to the beginning of the stream
+
+                    FlatFileReader reader = new FlatFileReader(new FixedLengthReader(stream, schema));
+                    Assert.IsTrue(reader.Read(), "The writer did not write the entities.");
+
+                    string value = reader.GetString(0);
+
                     Assert.AreEqual("67890", value, "The value was not truncated properly.");
                     Assert.IsFalse(reader.Read(), "The writer wrote too many records.");
                 }

--- a/FlatFiles.Test/FlatFiles.Test.csproj
+++ b/FlatFiles.Test/FlatFiles.Test.csproj
@@ -54,6 +54,7 @@
     <Compile Include="DataTableExtensionsTester.cs" />
     <Compile Include="FixedLengthSchemaTester.cs" />
     <Compile Include="FixedLengthReaderTester.cs" />
+    <Compile Include="FixedLengthWriterTester.cs" />
     <Compile Include="Int32ColumnTester.cs" />
     <Compile Include="DateTimeColumnTester.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/FlatFiles/FixedLengthWriter.cs
+++ b/FlatFiles/FixedLengthWriter.cs
@@ -182,5 +182,14 @@ namespace FlatFiles
                 return value;
             }
         }
+
+        /// <summary>
+        /// Clears all buffers for the current writer and causes any buffered data to be written to
+        /// the underlying stream.
+        /// </summary>
+        public void Flush()
+        {
+            writer.Flush();
+        }
     }
 }

--- a/FlatFiles/FixedLengthWriter.cs
+++ b/FlatFiles/FixedLengthWriter.cs
@@ -163,7 +163,9 @@ namespace FlatFiles
             Window window = schema.Windows[columnIndex];
             if (value.Length > window.Width)
             {
-                int start = value.Length - window.Width;  // take characters on the end
+                // Truncate the value, keeping the start if the value is left-aligned, or
+                // otherwise keeping the end if the value is right-aligned.
+                int start = window.Alignment == FixedAlignment.LeftAligned ? 0 : value.Length - window.Width;
                 return value.Substring(start, window.Width);
             }
             else if (value.Length < window.Width)

--- a/FlatFiles/Window.cs
+++ b/FlatFiles/Window.cs
@@ -25,6 +25,16 @@ namespace FlatFiles
         }
 
         /// <summary>
+        /// Initializes a new instance of a Window.
+        /// </summary>
+        /// <param name="width">The maximum possible width of the column.</param>
+        /// <param name="Alignment">Alignment of the value in the column</param>
+        public Window(int width, FixedAlignment Alignment) : this(width)
+        {
+            this.Alignment = Alignment;
+        }
+
+        /// <summary>
         /// Gets the width of the column.
         /// </summary>
         public int Width 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or, if the schema is for a fixed-length file:
       .AddColumn(new DateTimeColumn("created", 8) { InputFormat = "yyyyMMdd", OutputFormat = "yyyyMMdd" })
       .AddColumn(new DoubleColumn("avg_sales", 10) { OutputFormat = "N2" });
 	  
-The `FixedLengthSchema` class is the same as the `SeparatedValueSchema` class, except it associates a `Window` to each column. A `Window` records the `Width` of the column in the file. It also allows you to specify the `Alignment` (left or right) in cases where the value doesn't fill the entire width of the column (the default is left aligned). The `FillCharacter` property can be used to say what character is used as padding.
+The `FixedLengthSchema` class is the same as the `SeparatedValueSchema` class, except it associates a `Window` to each column. A `Window` records the `Width` of the column in the file. It also allows you to specify the `Alignment` (left or right) in cases where the value doesn't fill the entire width of the column (the default is left aligned). The `FillCharacter` property can be used to say what character is used as padding. Note the `Alignment` is also used to determine which part of the value to keep if the value is too wide to fit inside the column (e.g., if the column is left-aligned, only the start of the value will be kept).
 
 Some fixed-length files may have columns that are not used. The fixed-length schema doesn't provide a way to specify a starting index for a column. Simply define "ignored" columns for gaps in the input file.
 


### PR DESCRIPTION
Hello,

I'm considering using this library for generating reports, and noticed one issue with the truncation behavior for fixed width files.  Currently, if the value is too wide to fit inside the field, the behavior is to always keep the end of the value.  I think it would be a lot more intuitive to change this behavior so that it respects the Alignment value.  So, if the field is normally left-aligned, then the start will be kept; if the field is right-aligned, then the end is kept.

An alternative would be to create a separate property inside Window to specify the truncation behavior (instead of reusing Alignment) - if you like this idea better, let me know and I can put up a new pull request.