### PR TITLE
Clean up code redundancies

### DIFF
--- a/FlatFiles.Benchmark/CoreBenchmarkSuite.cs
+++ b/FlatFiles.Benchmark/CoreBenchmarkSuite.cs
@@ -350,7 +350,7 @@ namespace FlatFiles.Benchmark
         public void RunCsvHelper()
         {
             StringReader reader = new StringReader(data);
-            var csvReader = new CsvHelper.CsvReader(reader, new Configuration() { });
+            var csvReader = new CsvHelper.CsvReader(reader, new Configuration());
             var people = csvReader.GetRecords<Person>().ToArray();
         }
 
@@ -358,7 +358,7 @@ namespace FlatFiles.Benchmark
         public async Task RunCsvHelper_Async()
         {
             StringReader reader = new StringReader(data);
-            var csvReader = new CsvHelper.CsvReader(reader, new Configuration() { });
+            var csvReader = new CsvHelper.CsvReader(reader, new Configuration());
             List<Person> people = new List<Person>();
             await csvReader.ReadAsync().ConfigureAwait(false);
             csvReader.ReadHeader();

--- a/FlatFiles.Test/CustomMappingTester.cs
+++ b/FlatFiles.Test/CustomMappingTester.cs
@@ -69,7 +69,7 @@ namespace FlatFiles.Test
             {
                 person.Name = (string)value;
             }).WithWriter(p => p.Name);
-            mapper.CustomMapping(new DateTimeColumn("CreatedOn")).WithReader(p => p.CreatedOn).WithWriter(p => p.CreatedOn);;
+            mapper.CustomMapping(new DateTimeColumn("CreatedOn")).WithReader(p => p.CreatedOn).WithWriter(p => p.CreatedOn);
             mapper.CustomMapping(new DecimalColumn("Amount")).WithReader((ctx, person, value) =>
             {
                 person.Amount = value == null ? (decimal?)null : (decimal)value;

--- a/FlatFiles.Test/FixedLengthAsyncReaderTester.cs
+++ b/FlatFiles.Test/FixedLengthAsyncReaderTester.cs
@@ -74,7 +74,7 @@ namespace FlatFiles.Test
             {
                 people.Add(reader.Current);
             }
-            Assert.AreEqual(2, people.Count());
+            Assert.AreEqual(2, people.Count);
             var person1 = people.First();
             Assert.AreEqual(bob.Id, person1.Id);
             Assert.AreEqual(bob.Name, person1.Name);

--- a/FlatFiles.Test/FixedLengthReaderTester.cs
+++ b/FlatFiles.Test/FixedLengthReaderTester.cs
@@ -398,6 +398,7 @@ a weird row that should be skipped
             var people = mapper.Read(stringReader, options).ToArray();
             Assert.AreEqual(1, people.Length);
             var person = people.SingleOrDefault();
+            Assert.IsNotNull(person);
             Assert.AreEqual(bob.Id, person.Id);
             Assert.AreEqual(bob.Name, person.Name);
             Assert.AreEqual(bob.Created, person.Created);
@@ -426,6 +427,7 @@ a weird row that should be skipped
             var people = mapper.Read(stringReader, options).ToArray();
             Assert.AreEqual(1, people.Length);
             var person = people.SingleOrDefault();
+            Assert.IsNotNull(person);
             Assert.AreEqual(bob.Id, person.Id);
             Assert.AreEqual(bob.Name, person.Name);
             Assert.AreEqual(bob.Created, person.Created);
@@ -507,6 +509,7 @@ a weird row that should be skipped
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.IsNull(first.IsActive);
         }
 
@@ -525,6 +528,7 @@ a weird row that should be skipped
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.AreNotEqual(true, first.IsActive);
         }
 
@@ -543,6 +547,7 @@ a weird row that should be skipped
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.AreEqual(true, first.IsActive);
         }
 
@@ -577,7 +582,7 @@ a weird row that should be skipped
                 e.IsHandled = true;
             };
             var people = reader.ReadAll().ToArray();
-            Assert.AreEqual(2, people.Count());
+            Assert.AreEqual(2, people.Length);
             Assert.AreEqual(1, errorRecords.Count);
             Assert.AreEqual(2, errorRecords[0]);
         }
@@ -596,7 +601,7 @@ a weird row that should be skipped
             var options = new FixedLengthOptions() { HasRecordSeparator = true, RecordSeparator = null };
             var people = mapper.Read(stringReader, options).ToArray();
 
-            Assert.AreEqual(4, people.Count());
+            Assert.AreEqual(4, people.Length);
         }
     }
 }

--- a/FlatFiles.Test/SeparatedValueReaderTester.cs
+++ b/FlatFiles.Test/SeparatedValueReaderTester.cs
@@ -358,7 +358,6 @@ This is not a real record
             SeparatedValueReader parser = new SeparatedValueReader(stringReader, options);
             Assert.IsTrue(parser.Read(), "The record could not be read.");
             Assert.AreEqual(parser.GetSchema().ColumnDefinitions.Count, parser.GetValues().Length);
-            ;
         }
 
         /// <summary>
@@ -489,7 +488,7 @@ This is not a real record
 
             //---- Assert ------------------------------------------------------
             Assert.IsTrue(result);
-            Assert.AreEqual(schema.ColumnDefinitions.Count, testee.GetValues().Count());
+            Assert.AreEqual(schema.ColumnDefinitions.Count, testee.GetValues().Length);
         }
 
         /// <summary>
@@ -514,6 +513,7 @@ This is not a real record
             var people = mapper.Read(stringReader, options).ToArray();
             Assert.AreEqual(1, people.Length);
             var person = people.SingleOrDefault();
+            Assert.IsNotNull(person);
             Assert.AreEqual(bob.Id, person.Id);
             Assert.AreEqual(bob.Name, person.Name);
             Assert.AreEqual(bob.Created, person.Created);
@@ -541,6 +541,7 @@ This is not a real record
             var people = mapper.Read(stringReader, options).ToArray();
             Assert.AreEqual(1, people.Length);
             var person = people.SingleOrDefault();
+            Assert.IsNotNull(person);
             Assert.AreEqual(bob.Id, person.Id);
             Assert.AreEqual(bob.Name, person.Name);
             Assert.AreEqual(bob.Created, person.Created);
@@ -569,6 +570,7 @@ This is not a real record
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var person = people.SingleOrDefault();
+            Assert.IsNotNull(person);
             Assert.AreEqual(bob.Id, person.Id);
             Assert.AreEqual(bob.Name, person.Name);
             Assert.AreEqual(bob.Created, person.Created);
@@ -631,6 +633,7 @@ Stephen,Tyler,""7452 Terrace """"At the Plaza"""" road"",SomeTown,SD, 91234
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.IsNull(first.IsActive);
         }
 
@@ -649,6 +652,7 @@ Stephen,Tyler,""7452 Terrace """"At the Plaza"""" road"",SomeTown,SD, 91234
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.AreNotEqual(true, first.IsActive);
         }
 
@@ -667,6 +671,7 @@ Stephen,Tyler,""7452 Terrace """"At the Plaza"""" road"",SomeTown,SD, 91234
             var people = mapper.Read(stringReader).ToArray();
             Assert.AreEqual(1, people.Length);
             var first = people.SingleOrDefault();
+            Assert.IsNotNull(first);
             Assert.AreEqual(true, first.IsActive);
         }
 
@@ -690,7 +695,7 @@ Stephen,Tyler,""7452 Terrace """"At the Plaza"""" road"",SomeTown,SD, 91234
                 e.IsHandled = true;
             };
             var people = reader.ReadAll().ToArray();
-            Assert.AreEqual(2, people.Count());
+            Assert.AreEqual(2, people.Length);
             Assert.AreEqual(1, errorRecords.Count);
             Assert.AreEqual(2, errorRecords[0]);
         }

--- a/FlatFiles/ColumnContext.cs
+++ b/FlatFiles/ColumnContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Holds information about the column currently being processed.
@@ -37,7 +35,6 @@ namespace FlatFiles
             get
             {
                 var schema = RecordContext.ExecutionContext.Schema;
-                var columns = schema.ColumnDefinitions;
                 IColumnDefinition definition = schema.ColumnDefinitions[PhysicalIndex];
                 return definition;
             }

--- a/FlatFiles/ExecutionContext.cs
+++ b/FlatFiles/ExecutionContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Holds information about the currently running process.

--- a/FlatFiles/FixedAlignment.cs
+++ b/FlatFiles/FixedAlignment.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Gets the alignment of a fixed width column.

--- a/FlatFiles/FlatFileDataReader.cs
+++ b/FlatFiles/FlatFileDataReader.cs
@@ -248,6 +248,10 @@ namespace FlatFiles
         /// <returns>The number of chars copied to the buffer.</returns>
         public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
             var values = GetValues();
             var chars = (char[])values[i];
 #if NET45

--- a/FlatFiles/FlatFileDataReaderOptions.cs
+++ b/FlatFiles/FlatFileDataReaderOptions.cs
@@ -1,6 +1,4 @@
 ﻿#if NET45||NETStandard20
-using System;
-
 namespace FlatFiles
 {
     /// <summary>

--- a/FlatFiles/INullHandler.cs
+++ b/FlatFiles/INullHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Specifies which value represents nulls within a file.

--- a/FlatFiles/IOptions.cs
+++ b/FlatFiles/IOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Represents reader/writer options that are common among file types.

--- a/FlatFiles/IRecordParsedEventArgs.cs
+++ b/FlatFiles/IRecordParsedEventArgs.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Holds the information related to a parsed record.

--- a/FlatFiles/MetadataColumn.cs
+++ b/FlatFiles/MetadataColumn.cs
@@ -35,7 +35,7 @@ namespace FlatFiles
         /// <param name="context">Holds information about the column current being processed.</param>
         /// <param name="value">The object to format.</param>
         /// <returns>The formatted value.</returns>
-        public override sealed string Format(IColumnContext context, object value)
+        public sealed override string Format(IColumnContext context, object value)
         {
             return OnFormat(context);
         }

--- a/FlatFiles/OverflowTruncationPolicy.cs
+++ b/FlatFiles/OverflowTruncationPolicy.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Specifies how to truncate columns when the data exceeds to maximum width.

--- a/FlatFiles/QuoteBehavior.cs
+++ b/FlatFiles/QuoteBehavior.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     ///  Specifies how FlatFiles should quote separated value file fields.

--- a/FlatFiles/RecordContext.cs
+++ b/FlatFiles/RecordContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Holds information about the record currently being processed.

--- a/FlatFiles/RecordNumberColumn.cs
+++ b/FlatFiles/RecordNumberColumn.cs
@@ -64,7 +64,6 @@ namespace FlatFiles
         /// <returns>The parsed value.</returns>
         protected override int OnParse(IColumnContext context)
         {
-            IFormatProvider provider = FormatProvider ?? CultureInfo.CurrentCulture;
             var recordNumber = GetRecordNumber(context);
             return recordNumber;
         }

--- a/FlatFiles/SeparatedValueSchema.cs
+++ b/FlatFiles/SeparatedValueSchema.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles
+﻿namespace FlatFiles
 {
     /// <summary>
     /// Defines the expected format of a record in a file.

--- a/FlatFiles/TypeMapping/IMapperSource.cs
+++ b/FlatFiles/TypeMapping/IMapperSource.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FlatFiles.TypeMapping
+﻿namespace FlatFiles.TypeMapping
 {
     internal interface IMapperSource
     {

--- a/FlatFiles/TypeMapping/SeparatedValueTypeMapper.cs
+++ b/FlatFiles/TypeMapping/SeparatedValueTypeMapper.cs
@@ -219,7 +219,7 @@ namespace FlatFiles.TypeMapping
                     return null;
                 }
                 // If there is more than one match, do an exact match
-                return propertyInfos.Where(i => i.Name == column.ColumnName).SingleOrDefault();
+                return propertyInfos.SingleOrDefault(i => i.Name == column.ColumnName);
             }
             return propertyInfos.SingleOrDefault();
         }
@@ -237,7 +237,7 @@ namespace FlatFiles.TypeMapping
                     return null;
                 }
                 // If there is more than one match, do an exact match
-                return fieldInfos.Where(i => i.Name == column.ColumnName).SingleOrDefault();
+                return fieldInfos.SingleOrDefault(i => i.Name == column.ColumnName);
             }
             return fieldInfos.SingleOrDefault();
         }


### PR DESCRIPTION
I used Resharper to identify some code redundancies and clean up. I was very careful not to make any changes that would change behavior or change method/properties definition.  The list below is basically in the same order as the changed files.

- Remove empty object initializers
- Empty statements (extra semicolons)
- Added Assert.IsNotNull( obj ) in unit tests where could have been null reference exceptions
- Changed calls from .Count() extension method to .Length or .Count property accessors
- Remove redundant 'using statements' and redundant statements, ie ColumnContext.cs unused variable var columns = schema.ColumnDefinitions;  
- Added null argument check to fail fast on FlatFileDataReader.GetChars since Array.Copy would throw ArgumentNullException if buffer was null
- Fixed order of modifiers "public **override sealed** string Format(" to "public **sealed override** string Format("
- changed .Where(...).SingleOrDefault() to .SingleOrDefault(...)