### PR TITLE
added option to never quote a string in separate value record writer

### DIFF
--- a/FlatFiles/QuoteBehavior.cs
+++ b/FlatFiles/QuoteBehavior.cs
@@ -12,6 +12,10 @@
         /// <summary>
         /// FlatFiles will put quotes around all values.
         /// </summary>
-        AlwaysQuote = 1
+        AlwaysQuote = 1,
+        /// <summary>
+        /// FlatFiles will never put quotes around values.
+        /// </summary>
+        Never = 2
     }
 }

--- a/FlatFiles/SeparatedValueRecordWriter.cs
+++ b/FlatFiles/SeparatedValueRecordWriter.cs
@@ -115,6 +115,10 @@ namespace FlatFiles
             {
                 return true;
             }
+            if (Metadata.ExecutionContext.Options.QuoteBehavior == QuoteBehavior.Never)
+            {
+                return false;
+            }
             // Don't escape empty strings.
             if (value == String.Empty)
             {


### PR DESCRIPTION
The seperated value record writer only supports quote behavior "always" and "default". I had to recreate a file that was existing in a certain format and didn't have any quotes. This file is read by a third party application we can't change, so I added a new option "never" for quote behavior. Could also be useful for others.