### PR TITLE
GetValues() maps DbNull to Null

### DIFF
--- a/FlatFiles.Test/DataRecordExtensionsTester.cs
+++ b/FlatFiles.Test/DataRecordExtensionsTester.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.IO;
 using System.Linq;
 using FlatFiles.TypeMapping;
@@ -68,6 +69,17 @@ namespace FlatFiles.Test
             Assert.IsFalse(dataReader.Read(), "Too many records were read.");
         }
 
+
+        [TestMethod]
+        public void TestGetValues_DbNullToNull()
+        {
+            var record = new MockDataRecord();
+            var values = record.GetValues();
+
+            Assert.AreEqual(6, values.Length);
+            Assert.AreEqual(null, values[2]);
+        }
+
         private static SeparatedValueSchema GetSchema()
         {
             var mapper = SeparatedValueTypeMapper.Define(() => new NullableValues());
@@ -110,6 +122,142 @@ namespace FlatFiles.Test
             public Guid? GuidValue { get; set; }
 
             public DayOfWeek? EnumValue { get; set; }
+        }
+
+        private class MockDataRecord : IDataRecord
+        {
+            private readonly object[] _values =
+            {
+                0, DateTime.UnixEpoch, DBNull.Value, 3.14159, 3.14159m, "A String"
+            };
+
+            public bool GetBoolean(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte GetByte(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public char GetChar(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDataReader GetData(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetDataTypeName(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public DateTime GetDateTime(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public decimal GetDecimal(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public double GetDouble(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Type GetFieldType(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public float GetFloat(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Guid GetGuid(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public short GetInt16(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetInt32(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetInt64(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetName(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetOrdinal(string name)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetString(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object GetValue(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetValues(object[] values)
+            {
+                int i;
+                for (i = 0; i < values.Length && i < _values.Length; i++)
+                {
+                    values[i] = _values[i];
+                }
+
+                return i;
+            }
+
+            public bool IsDBNull(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int FieldCount => _values.Length;
+
+            public object this[int i]
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public object this[string name]
+            {
+                get { throw new NotImplementedException(); }
+            }
         }
     }
 }

--- a/FlatFiles/DataRecordExtensions.cs
+++ b/FlatFiles/DataRecordExtensions.cs
@@ -1023,6 +1023,13 @@ namespace FlatFiles
         {
             var values = new object[record.FieldCount];
             record.GetValues(values);
+            for (int i = 0; i < values.Length; i++)
+            {
+                if (values[i] == DBNull.Value)
+                {
+                    values[i] = null;
+                }
+            }
             return values;
         }
 


### PR DESCRIPTION
**Summary:**

When you call `FixedLengthWriter.Write(SqlDataReader.GetValues())` and a DbNull is one of the values in the array returned, the parser blows up.


**Check list:**
- [x] If this is a new feature, was a feature request created for it and discussed with the project coordinators?
- [x] After making your change, have all unit tests been updated and ran successfully?
- [x] Did you write new tests to cover any new features?
- [x] Did you clean your code to use best coding practices?
- [x] Are all changes relevant/necessary for your change?
- [ ] Did you run the performance project before and after to verify your changes did not degrade performance?
